### PR TITLE
Added parity to serial settings dictionary

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -12,6 +12,7 @@ serialSettings = dict(
     port = '/dev/ttyAMA0',
     baudrate = 9600,
     timeout = 0.5
+    parity = 'none'
 )
 
 # deviceSettings is a list of dictionaries for each device to be read

--- a/readmodbus.py
+++ b/readmodbus.py
@@ -19,6 +19,11 @@ class ReadModbus():
             self.instrument.serial.baudrate = serialSettings['baudrate']
         if 'timeout' in serialSettings:
             self.instrument.serial.timeout = serialSettings['timeout']
+        if 'parity' in serialSettings:
+            if serialSettings['parity'] == 'even':
+                self.instrument.serial.parity = minimalmodbus.serial.PARITY_EVEN
+            else:
+                self.instrument.serial.parity = minimalmodbus.serial.PARITY_NONE
         #TODO add other serial settings
         
         # Load the modbus map


### PR DESCRIPTION
To enable communication with or-we-516 added possibility set serial settings parity to even